### PR TITLE
feat(kubernetes): overridable server config + correct rke2 join port

### DIFF
--- a/modules/kubernetes/nixos.nix
+++ b/modules/kubernetes/nixos.nix
@@ -13,7 +13,6 @@
   inherit (nixidy) k8s;
   cfg = config.services.${k8s};
   isRoot = node.name == root;
-  # k3s serves the supervisor (node registration) on 6443; rke2 uses 9345.
   supervisorPort =
     if k8s == "rke2"
     then 9345
@@ -36,8 +35,6 @@ in {
       virtualisation.containerd.enable = true;
     }
     (lib.mkIf (cfg.role == "server") {
-      # mkDefault so downstream can override per-key (re-enable the scheduler,
-      # extend tls-san, etc.) without mkForce.
       canivete.kubernetes.yaml = {
         disable-cloud-controller = lib.mkDefault true;
         disable-kube-proxy = lib.mkDefault true;

--- a/modules/kubernetes/nixos.nix
+++ b/modules/kubernetes/nixos.nix
@@ -40,7 +40,7 @@ in {
         disable-kube-proxy = lib.mkDefault true;
         disable-scheduler = lib.mkDefault true;
         etcd-expose-metrics = lib.mkDefault true;
-        tls-san = lib.mkDefault [domain];
+        tls-san = lib.mkDefault (lib.unique [domain kubernetes.serverEndpoint]);
       };
     })
     (lib.mkIf isRoot {services.${k8s}.role = "server";})

--- a/modules/kubernetes/nixos.nix
+++ b/modules/kubernetes/nixos.nix
@@ -13,10 +13,16 @@
   inherit (nixidy) k8s;
   cfg = config.services.${k8s};
   isRoot = node.name == root;
+  # k3s serves the supervisor (node registration) on 6443; rke2 uses 9345.
+  supervisorPort =
+    if k8s == "rke2"
+    then 9345
+    else 6443;
 in {
   options.canivete.kubernetes = {
     enable = can.enable "kubernetes as a service" {};
     yaml = can.yaml.option pkgs "settings for config.yaml" {};
+    serverEndpoint = can.str "host non-root nodes register against; point at a load balancer for an HA control plane" {default = domain;};
   };
   config = lib.mkIf kubernetes.enable (lib.mkMerge [
     {
@@ -30,16 +36,18 @@ in {
       virtualisation.containerd.enable = true;
     }
     (lib.mkIf (cfg.role == "server") {
+      # mkDefault so downstream can override per-key (re-enable the scheduler,
+      # extend tls-san, etc.) without mkForce.
       canivete.kubernetes.yaml = {
-        disable-cloud-controller = true;
-        disable-kube-proxy = true;
-        disable-scheduler = true;
-        etcd-expose-metrics = true;
-        tls-san = [domain];
+        disable-cloud-controller = lib.mkDefault true;
+        disable-kube-proxy = lib.mkDefault true;
+        disable-scheduler = lib.mkDefault true;
+        etcd-expose-metrics = lib.mkDefault true;
+        tls-san = lib.mkDefault [domain];
       };
     })
     (lib.mkIf isRoot {services.${k8s}.role = "server";})
-    (lib.mkIf (!isRoot) {canivete.kubernetes.yaml.server = "https://${domain}:6443";})
+    (lib.mkIf (!isRoot) {canivete.kubernetes.yaml.server = "https://${kubernetes.serverEndpoint}:${toString supervisorPort}";})
     (lib.mkIf (k8s == "k3s") (lib.mkMerge [
       {services.k3s.gracefulNodeShutdown.enable = true;}
       (lib.mkIf isRoot {services.k3s.clusterInit = true;})


### PR DESCRIPTION
## What

Two changes to `modules/kubernetes/nixos.nix`:

1. **Overridable server defaults.** The `role == "server"` config.yaml block (`disable-scheduler`, `tls-san`, `disable-kube-proxy`, etc.) used plain values, so any downstream that needs servers to schedule or needs extra TLS SANs had to `lib.mkForce` them. They're now `mkDefault` — overridable per-key.

2. **Correct rke2 node registration.** Non-root nodes registered at `https://${domain}:6443`. For rke2 the supervisor/join port is **9345** (6443 is the kube-apiserver; only k3s serves the supervisor on 6443), so multi-node rke2 joins pointed at the wrong port. The port is now distro-aware, and a new `serverEndpoint` option (default: the cluster domain) lets joins target an HA load balancer instead of a single node.

## Why

Standing up a self-managed multi-server (HA) rke2 cluster on canivete required `mkForce` on `disable-scheduler`, `tls-san`, and `server` purely to fight these plain defaults — a smell that the defaults should be overridable. The 6443 -> 9345 fix also closes a latent join bug on the rke2 path.

## Validation

Evaluated a downstream rke2 node (`nixosConfigurations.prod-server-0`) against clean `trunk` vs this branch: identical derivation (`bms9vivq...`), so the change is behavior-neutral for existing consumers. Backward compatible — k3s keeps 6443, `serverEndpoint` defaults to `domain`, and `mkDefault` preserves every current effective value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes server endpoint option to customize cluster communication settings

* **Improvements**
  * Kubernetes supervisor port now auto-selected based on distribution (6443 for k3s, 9345 for rke2)
  * Default Kubernetes configurations made flexible, allowing customization without forced values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->